### PR TITLE
refactor of form field visibility toggle

### DIFF
--- a/app/partials/pet-details-form.php
+++ b/app/partials/pet-details-form.php
@@ -126,24 +126,24 @@
     <?php if ($page =='index') { ?>
 
         <p class="c-radio-switch">
-            <input id="both-chipped" type="radio" value="all" name="is_chipped" class="c-radio-switch__input" checked>
+            <input id="both-chipped" type="radio" value="all" name="is_chipped" class="c-radio-switch__input  js-field-toggle-trigger"  data-toggle-target="chip-number-wrap" checked>
             <label for="both-chipped" class="c-radio-switch__label">All</label>
         </p>
 
     <?php } ?>
 
         <p class="c-radio-switch">
-            <input id="chipped" type="radio" value="chipped" name="is_chipped" class="c-radio-switch__input">
+            <input id="chipped" type="radio" value="true" name="is_chipped" class="c-radio-switch__input  js-field-toggle-trigger"  data-toggle-target="chip-number-wrap" data-toggle-target-visibility="true">
             <label for="chipped" class="c-radio-switch__label">Yes</label>
         </p>
 
         <p class="c-radio-switch">
-            <input id="not-chipped" type="radio" value="not-chipped" name="is_chipped" class="c-radio-switch__input">
+            <input id="not-chipped" type="radio" value="false" name="is_chipped" class="c-radio-switch__input  js-field-toggle-trigger"  data-toggle-target="chip-number-wrap">
             <label for="not-chipped" class="c-radio-switch__label">No</label>
         </p>
     </div>
 
-    <p id="chip-number-wrap" class="h-spacing-base h-hide">
+    <p id="chip-number-wrap" class="h-spacing-base h-hide js-field-toggle-target">
         <label for="chip-number">Chip number:</label>
         <input type="text" id="chip-number" name="chip_number" class="c-textual-input">
     </p>

--- a/app/src/js/main.js
+++ b/app/src/js/main.js
@@ -3,7 +3,9 @@ const petDetectrApp = petDetectrApp || {};
 petDetectrApp.formSetup = function formSetup(formName = 'report_form') {
     // Pet info
     this.petStatusInput = document[formName].status;
-    this.isChippedInput = document[formName].is_chipped;
+
+    // Toggle fields
+    this.toggleTriggerFields = document[formName].getElementsByClassName('js-field-toggle-trigger');
 
     // Required fields
     this.requiredFields = document[formName].getElementsByClassName('js-required-field');
@@ -11,10 +13,10 @@ petDetectrApp.formSetup = function formSetup(formName = 'report_form') {
 
     // Grab radio buttons and text nodes
     this.lastSeenText = document.querySelectorAll('.js-seen-found-text');
-    this.chipNumber = document.querySelector('#chip-number-wrap');
+
 
     this.addEventToNodes('click', this.petStatusInput, this.updateDateAndLocationText);
-    this.addEventToNodes('click', this.isChippedInput, this.hideShowChipNumber);
+    this.addEventToNodes('click', this.toggleTriggerFields, this.toggleFieldVisibility);
 
     // Basic required validation
     this.addEventToNodes('blur', this.requiredFields, this.validateRequired);
@@ -68,11 +70,12 @@ petDetectrApp.setHideShow = function showHideElement(target, display) {
 };
 
 // Chip number h-hide switching
-petDetectrApp.hideShowChipNumber = function hideShowChipNumber(e) {
-    const self = petDetectrApp;
-    const isChipped = e.target.value === 'chipped';
+petDetectrApp.toggleFieldVisibility = function toggleFieldVisibility(e) {
+    // get data attributes
+    const radioToggleTarget = document.getElementById(e.target.dataset.toggleTarget);
+    const radioToggleVisibility = e.target.dataset.toggleTargetVisibility;
 
-    self.setHideShow(self.chipNumber, isChipped);
+    petDetectrApp.setHideShow(radioToggleTarget, radioToggleVisibility);
 };
 
 petDetectrApp.formSetup();


### PR DESCRIPTION
Small commit to make the radio toggle thing more generic so we could use it for other form fields e.g breeds only being visible when a species is selected etc.

Things I don't like / I'm not sure on:
- any of the naming really, so open to new class / data attribute name suggestions
- is there any reason not to use data attributes here?
- it would be good not to duplicate this 3 times `class="js-field-toggle-trigger"  data-toggle-target="chip-number-wrap` and be able to have it just be on the parent 

Feedback welcome :)
